### PR TITLE
Fix location of installed header files.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,11 +7,8 @@ lib_LTLIBRARIES = libJerasure.la
 libJerasure_la_SOURCES = galois.c jerasure.c reed_sol.c cauchy.c liberation.c
 libJerasure_la_LDFLAGS = -version-info 2:0:0
 libJerasure_la_LIBADD = -lgf_complete
-include_HEADERS = ../include/jerasure.h
-
-# Install additional Jerasure header files in their own directory.
-jerasureincludedir = $(includedir)/jerasure
-jerasureinclude_HEADERS = \
+include_HEADERS = \
+  ../include/jerasure.h \
   ../include/cauchy.h \
   ../include/galois.h \
   ../include/liberation.h \


### PR DESCRIPTION
This fixes the issue of missing includes when using
the system-wide header jerasure.h
